### PR TITLE
Pr440 reviewed

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -1,4 +1,12 @@
 # Shell completion scripts
 
-Please refer to each folder about how to install completion for `rmw` to your shell
+By default, rmw completions are installed when rmw is installed (This can be
+disabled by using '-Dinstall_shell_completions' during meson setup). If they
+aren't present on your system, you can install a shell completion manually by
+getting the completion from the rmw source package or git repository. See the
+links below for specific installation instructions for each completion.
 
+
+## Fish
+
+[Where to put completions](https://fishshell.com/docs/current/completions.html#where-to-put-completions)

--- a/completions/fish/README.md
+++ b/completions/fish/README.md
@@ -1,4 +1,0 @@
-# Fish Shell completion scripts
-
-Please find here how to install `rmw` completion for [fish](https://fishshell.com/)
-

--- a/completions/meson.build
+++ b/completions/meson.build
@@ -2,11 +2,11 @@ fish_comp = dependency('fish', required: false)
 
 if get_option('install_shell_completions')
   fish_files = files(
-    'fish/rmw.fish',
+    join_paths('fish', 'rmw.fish'),
   )
 
   # default location
-  fish_install_dir = join_paths(get_option('datadir'), 'fish/vendor_completions.d')
+  fish_install_dir = join_paths(get_option('datadir'), 'fish', 'vendor_completions.d')
 
   if fish_comp.found()
     # when needed we overload the variable

--- a/completions/meson.build
+++ b/completions/meson.build
@@ -6,7 +6,7 @@ if get_option('install_shell_completions')
   )
 
   # default location
-  fish_install_dir = get_option('datadir') + '/fish/vendor_completions.d'
+  fish_install_dir = join_paths(get_option('datadir'), 'fish/vendor_completions.d')
 
   if fish_comp.found()
     # when needed we overload the variable

--- a/meson.build
+++ b/meson.build
@@ -71,7 +71,10 @@ main_bin = executable(
   )
 
 subdir ('man')
-subdir('completions')
+
+if get_option('install_shell_completions')
+  subdir('completions')
+endif
 
 if get_option('build_tests')
   subdir ('test')


### PR DESCRIPTION
@ccoVeille Here's what ChatGPT said about using [join_paths()](https://mesonbuild.com/Reference-manual_functions.html#join_paths):

>In Meson, the `join_paths()` function is used to concatenate file paths in a platform-independent way. It ensures that the correct directory separator is used for the operating system on which the build is running. For example, it uses `\` on Windows and `/` on Unix-like systems.

>Using the `+` operator to concatenate paths is not recommended because it can lead to issues with cross-platform compatibility. For instance, if you hardcode the directory separator as `/` and then run your build on Windows, the resulting paths may not be recognized by the Windows file system.

>By using `join_paths()`, you can write build scripts that are more portable and less likely to encounter path-related issues when building on different operating systems.